### PR TITLE
Fix copying env files not in the project root directory

### DIFF
--- a/dkp/dkp.py
+++ b/dkp/dkp.py
@@ -417,7 +417,7 @@ def backup(
             target.parent.mkdir(exist_ok=True, parents=True)
             print(f"copying env file {env_file.name} to "
                   f"{target.relative_to(work_dir)}")
-            fs_copy(env_file.name, target)
+            fs_copy(env_file, target)
 
         # add restore script
         gen_scripts(work_dir, info, sources)


### PR DESCRIPTION
Previously env file copying worked only when the following three directories were the same:

* current directory;
* project root directory;
* the env file's parent directory.

The previous commit wanted to solve this, but it contained a bug. This also made the automatic tests fail.

This commit fixes that bug.

The tests also pass: https://github.com/hcs42/dkp/commit/4dab1b0bafcf2bc82c3ec0c4b93a2dced54d7da1